### PR TITLE
Fix 'deleted signal remains on map'

### DIFF
--- a/app/src/main/java/org/helpapaw/helpapaw/signaldetails/SignalDetailsFragment.java
+++ b/app/src/main/java/org/helpapaw/helpapaw/signaldetails/SignalDetailsFragment.java
@@ -410,6 +410,8 @@ public class SignalDetailsFragment extends BaseFragment
 
     @Override
     public void closeScreenWithResult(Signal signal) {
+        if (getActivity() == null) return;
+
         Intent data = new Intent();
         data.putExtra("signal", signal);
         getActivity().setResult(Activity.RESULT_OK, data);

--- a/app/src/main/java/org/helpapaw/helpapaw/signalsmap/SignalsMapContract.java
+++ b/app/src/main/java/org/helpapaw/helpapaw/signalsmap/SignalsMapContract.java
@@ -85,11 +85,10 @@ interface SignalsMapContract {
 
         void onFilterSignalsButtonClicked();
 
-        void onSignalStatusUpdated(Signal signal);
+        void onSignalUpdated(Signal signal);
 
         void onAuthenticationAction();
 
         void onLoginAction();
-
     }
 }

--- a/app/src/main/java/org/helpapaw/helpapaw/signalsmap/SignalsMapFragment.java
+++ b/app/src/main/java/org/helpapaw/helpapaw/signalsmap/SignalsMapFragment.java
@@ -396,7 +396,16 @@ public class SignalsMapFragment extends BaseFragment
             mDisplayedSignals.add(newSignal);
         }
 
-        // Remove signals that do not are not included in current filter
+        // Remove any deleted signals
+        ArrayList<Signal> notDeletedSignals = new ArrayList<>();
+        for (Signal signal : mDisplayedSignals) {
+            if (!signal.getIsDeleted()) {
+                notDeletedSignals.add(signal);
+            }
+        }
+        mDisplayedSignals = notDeletedSignals;
+
+        // Remove signals that are not included in current filter
         if (selectedTypes != null) {
             ArrayList<Signal> filteredSignals = new ArrayList<>();
             for (Signal signal : mDisplayedSignals) {
@@ -802,7 +811,7 @@ public class SignalsMapFragment extends BaseFragment
             if (resultCode == Activity.RESULT_OK) {
                 Signal signal = data.getParcelableExtra("signal");
                 if (signal != null) {
-                    actionsListener.onSignalStatusUpdated(signal);
+                    actionsListener.onSignalUpdated(signal);
                 }
             }
         }

--- a/app/src/main/java/org/helpapaw/helpapaw/signalsmap/SignalsMapPresenter.java
+++ b/app/src/main/java/org/helpapaw/helpapaw/signalsmap/SignalsMapPresenter.java
@@ -23,9 +23,9 @@ import org.helpapaw.helpapaw.utils.Utils;
 public class SignalsMapPresenter extends Presenter<SignalsMapContract.View>
         implements SignalsMapContract.UserActionsListener, UploadPhotoContract.UserActionsListener {
 
-    private UserManager userManager;
-    private SignalRepository signalRepository;
-    private PhotoRepository photoRepository;
+    private final UserManager userManager;
+    private final SignalRepository signalRepository;
+    private final PhotoRepository photoRepository;
 
     private double latitude;
     private double longitude;
@@ -304,7 +304,7 @@ public class SignalsMapPresenter extends Presenter<SignalsMapContract.View>
     }
 
     @Override
-    public void onSignalStatusUpdated(Signal signal) {
+    public void onSignalUpdated(Signal signal) {
         if (signal == null) return;
 
         replaceSignal(signal);
@@ -316,9 +316,9 @@ public class SignalsMapPresenter extends Presenter<SignalsMapContract.View>
             Signal currentSignal = signalsList.get(i);
             if (currentSignal.getId().equals(signal.getId())) {
                 signalsList.remove(i);
+                signalsList.add(signal);
                 break;
             }
-            signalsList.add(signal);
         }
     }
 

--- a/app/src/main/res/layout/fragment_signal_details.xml
+++ b/app/src/main/res/layout/fragment_signal_details.xml
@@ -64,6 +64,7 @@
                                 android:layout_marginStart="4dp"
                                 android:layout_marginTop="4dp"
                                 android:drawableStart="@drawable/ic_cloud_upload_24"
+                                android:drawablePadding="4dp"
                                 android:text="@string/txt_upload_photo"
                                 android:visibility="invisible" />
                         </FrameLayout>


### PR DESCRIPTION
When a signal is deleted from details screen it is still shown on the map. Furthermore if you consequently open it, there is no indication that it is indeed deleted.